### PR TITLE
UI遷移2種類の実装（ステータスパネル & スマホオブジェクト表示）

### DIFF
--- a/Assets/_A_Scene/InGame.unity
+++ b/Assets/_A_Scene/InGame.unity
@@ -8288,6 +8288,54 @@ Transform:
   m_Children: []
   m_Father: {fileID: 2020516734}
   m_LocalEulerAnglesHint: {x: 0.89, y: 88.3, z: 0}
+--- !u!1 &1232041680
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1232041681}
+  - component: {fileID: 1232041682}
+  m_Layer: 0
+  m_Name: UIPhoneManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1232041681
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1232041680}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1355886702}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1232041682
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1232041680}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 71d416d10e54efe4f826b07cf4280cbd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _beforePhone: {fileID: 1347772012}
+  _afterPhone: {fileID: 141032065}
+  _phoneObject: {fileID: 339586085}
+  swipeSpeed: 50
 --- !u!1 &1248290536
 GameObject:
   m_ObjectHideFlags: 0
@@ -9068,6 +9116,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2049203053}
+  - {fileID: 1232041681}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1379086011

--- a/Assets/_A_Scene/InGame.unity
+++ b/Assets/_A_Scene/InGame.unity
@@ -7509,6 +7509,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6264f3dd07bfa5e4a859daf527ee9a89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _audioClip: {fileID: 0}
 --- !u!114 &1101189497
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -9037,6 +9038,38 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1347772012}
   m_CullTransparentMesh: 1
+--- !u!1 &1355886701
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1355886702}
+  m_Layer: 0
+  m_Name: PanelManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1355886702
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1355886701}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2049203053}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1379086011
 GameObject:
   m_ObjectHideFlags: 0
@@ -11934,7 +11967,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1911302150}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 2049203052}
+        m_TargetAssemblyTypeName: InGamePanelController, Assembly-CSharp
+        m_MethodName: HidePanel
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &1911302150
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -13248,6 +13293,51 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _isDontFly: 1
+--- !u!1 &2049203051
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2049203053}
+  - component: {fileID: 2049203052}
+  m_Layer: 0
+  m_Name: StatusPanelManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2049203052
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2049203051}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b764c44d8caeb5b4c9373a856aeaa3d2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _panel: {fileID: 437410559}
+--- !u!4 &2049203053
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2049203051}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1355886702}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2076606454
 GameObject:
   m_ObjectHideFlags: 0
@@ -136257,6 +136347,7 @@ SceneRoots:
   - {fileID: 1285888300}
   - {fileID: 754987235}
   - {fileID: 1530225807}
+  - {fileID: 1355886702}
   - {fileID: 1127150748}
   - {fileID: 1938931721}
   - {fileID: 29354091}

--- a/Assets/_B_Script/C_InGame/InGamePhoneController.cs
+++ b/Assets/_B_Script/C_InGame/InGamePhoneController.cs
@@ -16,7 +16,7 @@ public class InGamePhoneController : MonoBehaviour
 
     void Update()
     {
-        // === スマホタッチ ===
+        // === スマホ用 ===
         if (Touchscreen.current != null)
         {
             var touch = Touchscreen.current.primaryTouch;
@@ -35,8 +35,7 @@ public class InGamePhoneController : MonoBehaviour
             }
         }
 
-        // === PCデバッグ ===
-#if UNITY_EDITOR || UNITY_STANDALONE
+        // === PC用 ===
         if (Mouse.current.leftButton.wasPressedThisFrame)
         {
             startPos = Mouse.current.position.ReadValue();
@@ -48,7 +47,6 @@ public class InGamePhoneController : MonoBehaviour
             if (delta.x < -swipeSpeed && !isSlided) ShowPhone();
             else if (delta.x > swipeSpeed && isSlided) HidePhone();
         }
-#endif
     }
 
     private void ShowPhone()

--- a/Assets/_B_Script/C_InGame/InGamePhoneController.cs
+++ b/Assets/_B_Script/C_InGame/InGamePhoneController.cs
@@ -1,0 +1,69 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class InGamePhoneController : MonoBehaviour
+{
+    [Header("UI")]
+    [SerializeField] GameObject _beforePhone;
+    [SerializeField] GameObject _afterPhone;
+    [SerializeField] GameObject _phoneObject;
+
+    [Header("スワイプ判定")]
+    [SerializeField] float swipeSpeed = 50f;
+
+    Vector2 startPos;
+    bool isSlided = false;
+
+    void Update()
+    {
+        // === スマホタッチ ===
+        if (Touchscreen.current != null)
+        {
+            var touch = Touchscreen.current.primaryTouch;
+            var phase = touch.phase.ReadValue();
+
+            if (phase == UnityEngine.InputSystem.TouchPhase.Began)
+            {
+                startPos = touch.position.ReadValue();
+            }
+            else if (phase == UnityEngine.InputSystem.TouchPhase.Ended)
+            {
+                Vector2 delta = touch.position.ReadValue() - startPos;
+
+                if (delta.x < -swipeSpeed && !isSlided) ShowPhone();
+                else if (delta.x > swipeSpeed && isSlided) HidePhone();
+            }
+        }
+
+        // === PCデバッグ ===
+#if UNITY_EDITOR || UNITY_STANDALONE
+        if (Mouse.current.leftButton.wasPressedThisFrame)
+        {
+            startPos = Mouse.current.position.ReadValue();
+        }
+        if (Mouse.current.leftButton.wasReleasedThisFrame)
+        {
+            Vector2 delta = Mouse.current.position.ReadValue() - startPos;
+
+            if (delta.x < -swipeSpeed && !isSlided) ShowPhone();
+            else if (delta.x > swipeSpeed && isSlided) HidePhone();
+        }
+#endif
+    }
+
+    private void ShowPhone()
+    {
+        _beforePhone.SetActive(false);
+        _phoneObject.SetActive(true);
+        _afterPhone.SetActive(true);
+        isSlided = true;
+    }
+
+    private void HidePhone()
+    {
+        _phoneObject.SetActive(false);
+        _afterPhone.SetActive(false);
+        _beforePhone.SetActive(true);
+        isSlided = false;
+    }
+}

--- a/Assets/_B_Script/C_InGame/InGamePhoneController.cs.meta
+++ b/Assets/_B_Script/C_InGame/InGamePhoneController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 71d416d10e54efe4f826b07cf4280cbd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_B_Script/C_InGame/InGameUIController.cs
+++ b/Assets/_B_Script/C_InGame/InGameUIController.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 
 public class InGamePanelController : MonoBehaviour
 {
+    [Header("Ø‚è‘Ö‚¦‘ÎÛƒpƒlƒ‹")]
     [SerializeField] GameObject _panel;
     void Start()
     {

--- a/Assets/_B_Script/C_InGame/InGameUIController.cs
+++ b/Assets/_B_Script/C_InGame/InGameUIController.cs
@@ -1,0 +1,25 @@
+/// <summary>
+/// OnClick()で呼び出す前提
+/// Panel毎に対応したManagerを作成し、対象Panelをシリアライズに渡す
+/// </summary>
+
+using UnityEngine;
+
+public class InGamePanelController : MonoBehaviour
+{
+    [SerializeField] GameObject _panel;
+    void Start()
+    {
+        if (!_panel) Debug.LogError("Panelをアタッチしてください。");
+    }
+
+    public void ShowPanel()
+    {
+        _panel.SetActive(true);
+    }
+
+    public void HidePanel()
+    {
+        _panel.SetActive(false);
+    }
+}

--- a/Assets/_B_Script/C_InGame/InGameUIController.cs.meta
+++ b/Assets/_B_Script/C_InGame/InGameUIController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b764c44d8caeb5b4c9373a856aeaa3d2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 概要
- ステータスパネルを OnClick() で開閉できる仕組みを追加
- スマホアイコンのスワイプ操作でスマホオブジェクトを表示/非表示できる仕組みを追加
// 左スワイプでスマホ表示
// 右スワイプで非表示（PCではマウスドラッグで代替）